### PR TITLE
Set units of Network Transmit/Receive to bytes and not bytes per second

### DIFF
--- a/docker-monitoring-0.9.json
+++ b/docker-monitoring-0.9.json
@@ -456,8 +456,8 @@
           "x-axis": true,
           "y-axis": true,
           "y_formats": [
-            "Bps",
-            "Bps"
+            "bytes",
+            "bytes"
           ],
           "grid": {
             "leftLogBase": 1,


### PR DESCRIPTION
Whilst playing with the dashboard, I set up some additional where clauses to filter by a specific docker container I was interested in.  I noticed that after a performance test, the Network Transmit/Receive graph was showing what looked like the peak throughput consistently (flat line) despite the container sending and receiving no traffic at that point in time.

I think the issue is that the rx_bytes and tx_bytes measurements are accumulative and actually indicate the total data in and out.  This is why I propose that the units should just be bytes and not bytes per second.

Let me know if this makes sense!  

Thanks
  